### PR TITLE
Update OpenHardwareMonitor submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "openhardwaremonitor"]
 	path = openhardwaremonitor
-	url = https://github.com/openhardwaremonitor/openhardwaremonitor.git
+	url = https://github.com/nagiyu/openhardwaremonitor.git


### PR DESCRIPTION
This pull request updates the URL of the OpenHardwareMonitor submodule to https://github.com/nagiyu/openhardwaremonitor.git.